### PR TITLE
=bug #6 Fix NPE for absent records.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 To start working with Aerospike using this DSL you have to add dependency sbt:
 ```sh
-"ru.tinkoff" % "aerospike-scala" % "1.1.11",
+"ru.tinkoff" % "aerospike-scala" % "1.1.12",
 "com.aerospike" % "aerospike-client" % "3.3.1", // in case you don't have it
 "ru.tinkoff" % "aerospike-scala-example" % "1.1.11" // usage examples
 `````

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ val copyright = headers := Map(
 )
 
 val setts = Seq(organization := "ru.tinkoff",
-  version := "1.1.11",
+  version := "1.1.12",
   scalaVersion := "2.11.8",
   scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8"),
   copyright,

--- a/src/main/scala/ru/tinkoff/aerospike/dsl/GetProvider.scala
+++ b/src/main/scala/ru/tinkoff/aerospike/dsl/GetProvider.scala
@@ -61,14 +61,14 @@ trait GetProvider {
   def get(policy: BatchPolicy, records: util.List[BatchRead]): Future[Unit] =
     Future(client.get(policy, records))
 
-  def get(policy: BatchPolicy, keys: Array[Key], binNames: String*): Future[Array[Record]] =
-    Future(client.get(policy, keys, binNames: _*))
+  def get(policy: BatchPolicy, keys: Array[Key], binNames: String*): Array[Option[Record]] =
+    client.get(policy, keys, binNames: _*).map(Option.apply)
 
-  def get(policy: BatchPolicy, keys: Array[Key]): Future[Array[Record]] =
-    Future(client.get(policy, keys))
+  def get(policy: BatchPolicy, keys: Array[Key]): Array[Option[Record]] =
+    client.get(policy, keys).map(Option.apply)
 
-  def get(policy: Policy, key: Key, binNames: String*): Future[Record] =
-    Future(client.get(policy, key, binNames: _*))
+  def get(policy: Policy, key: Key, binNames: String*): Option[Record] =
+    Option(client.get(policy, key, binNames: _*))
 
-  def get(policy: Policy, key: Key): Future[Record] = Future(client.get(policy, key))
+  def get(policy: Policy, key: Key): Option[Record] = Option(client.get(policy, key))
 }

--- a/src/main/scala/ru/tinkoff/aerospike/dsl/Spike.scala
+++ b/src/main/scala/ru/tinkoff/aerospike/dsl/Spike.scala
@@ -25,38 +25,67 @@ import ru.tinkoff.aerospikescala.domain.ABin
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * @author MarinaSigaeva 
+  * @author MarinaSigaeva
   * @since 14.09.16
   */
 trait Spike {
 
   //for easy types call
-  def call(action: Call, any: Any = None)(implicit pw: Option[WritePolicy] = None, p: Option[Policy] = None,
-                                          bp: Option[BatchPolicy] = None, qp: Option[QueryPolicy] = None,
-                                          sp: Option[ScanPolicy] = None, ip: Option[InfoPolicy] = None): Future[Any]
+  def call(action: Call, any: Any = None)(
+      implicit pw: Option[WritePolicy] = None,
+      p: Option[Policy] = None,
+      bp: Option[BatchPolicy] = None,
+      qp: Option[QueryPolicy] = None,
+      sp: Option[ScanPolicy] = None,
+      ip: Option[InfoPolicy] = None): Future[Any]
 
   //for calls where you need to pass Key and Bin types (ru.tinkoff.aerospike.dsl.converters included)
-  def callKB[K, B](action: CallKB, k: K, b: ABin[B])(implicit kC: KeyWrapper[K], bC: BinWrapper[B], pw: Option[WritePolicy] = None): Future[Unit]
+  def callKB[K, B](action: CallKB, k: K, b: ABin[B])(
+      implicit kC: KeyWrapper[K],
+      bC: BinWrapper[B],
+      pw: Option[WritePolicy] = None): Future[Unit]
 
   //for calls where you need to pass List[Key] type (ru.tinkoff.aerospike.dsl.converters included)
-  def callKs[K](action: CallKs, ks: Array[K], any: Any = None)(implicit kC: KeyWrapper[K], bp: Option[BatchPolicy] = None,
-                                                               p: Option[Policy] = None, qp: Option[QueryPolicy] = None): Future[Any]
+  def callKs[K](action: CallKs, ks: Array[K], any: Any = None)(
+      implicit kC: KeyWrapper[K],
+      bp: Option[BatchPolicy] = None,
+      p: Option[Policy] = None,
+      qp: Option[QueryPolicy] = None): Future[Any]
 
   //for calls where you need to pass Key type (ru.tinkoff.aerospike.dsl.converters included)
-  def callK[K](action: CallK, k: K, any: Any = None)(implicit kC: KeyWrapper[K], p: Option[Policy] = None, pw: Option[WritePolicy] = None,
-                                                     bp: Option[BatchPolicy] = None, sp: Option[ScanPolicy] = None, ip: Option[InfoPolicy] = None): Future[Any]
+  def callK[K](action: CallK, k: K, any: Any = None)(
+      implicit kC: KeyWrapper[K],
+      p: Option[Policy] = None,
+      pw: Option[WritePolicy] = None,
+      bp: Option[BatchPolicy] = None,
+      sp: Option[ScanPolicy] = None,
+      ip: Option[InfoPolicy] = None): Future[Any]
 
-  def getByKey[K, B](k: K, bs: List[String] = Nil)(implicit kC: KeyWrapper[K], bC: BinWrapper[B],
-                                                   optP: Option[Policy] = None, ec: ExecutionContext): Future[(Map[String, Option[B]], Int, Int)]
+  def getByKey[K, B](k: K, bs: List[String] = Nil)(
+      implicit kC: KeyWrapper[K],
+      bC: BinWrapper[B],
+      optP: Option[Policy] = None,
+      ec: ExecutionContext): Future[Option[(Map[String, Option[B]], Int, Int)]]
 
-  def getByKeys[K, B](ks: Array[K], bs: List[String] = Nil)(implicit kC: KeyWrapper[K], bC: BinWrapper[B],
-                                                            optBP: Option[BatchPolicy] = None, ec: ExecutionContext): Future[List[(Map[String, Option[B]], Int, Int)]]
+  def getByKeys[K, B](ks: Array[K], bs: List[String] = Nil)(
+      implicit kC: KeyWrapper[K],
+      bC: BinWrapper[B],
+      optBP: Option[BatchPolicy] = None,
+      ec: ExecutionContext)
+    : Future[List[Option[(Map[String, Option[B]], Int, Int)]]]
 
-  def getByKeysWithListener[K, L](ks: Array[K], listener: L, bs: List[String] = Nil)
-                                 (implicit kC: KeyWrapper[K], optBP: Option[BatchPolicy] = None): Future[Unit]
+  def getByKeysWithListener[K, L](ks: Array[K],
+                                  listener: L,
+                                  bs: List[String] = Nil)(
+      implicit kC: KeyWrapper[K],
+      optBP: Option[BatchPolicy] = None): Future[Unit]
 
   //note, if you will not change namespace, setName parameters in BatchReadWrapper - default values from application.conf will be used
-  def getByKeysWithBatchListener[L](kws: List[BatchReadWrapper], listener: Option[L] = None)(implicit optBP: Option[BatchPolicy] = None): Future[Unit]
+  def getByKeysWithBatchListener[L](kws: List[BatchReadWrapper],
+                                    listener: Option[L] = None)(
+      implicit optBP: Option[BatchPolicy] = None): Future[Unit]
 
-  def deleteK[K](k: K)(implicit kC: KeyWrapper[K], pw: Option[WritePolicy] = None, e: ExecutionContext): Future[Boolean]
+  def deleteK[K](k: K)(implicit kC: KeyWrapper[K],
+                       pw: Option[WritePolicy] = None,
+                       e: ExecutionContext): Future[Boolean]
 }


### PR DESCRIPTION
Fix synchronous single-record read methods.

* Increment version.
* Fix ```def getByKey```. Wrap returned record in Option.
* Fix ```def getByKeys```. Wrap every returned record in Option.
* Wrap in Future already transformed results of both methods. No need to context switch here.